### PR TITLE
Use steam launch arguments when clearing steam cache 

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -737,7 +737,7 @@ namespace SteamFriendsPatcher
             if (preSteamStatus)
             {
                 Print("Restarting Steam...");
-                Process.Start(steamDir + "\\Steam.exe");
+                Process.Start(steamDir + "\\Steam.exe", Settings.Default.steamLaunchArgs);
                 for (var i = 0; i < 10; i++)
                 {
                     if (Process.GetProcessesByName("Steam").FirstOrDefault() != null)

--- a/Program.cs
+++ b/Program.cs
@@ -292,7 +292,7 @@ namespace SteamFriendsPatcher
 
             // custom overrides original (!important tags not needed)
             const string appendText =
-                "@import url(\"https://steamloopback.host/friends.original.css\");\n@import url(\"https://steamloopback.host/friends.custom.css\");\n{";
+                "@import url(\"https://steamloopback.host/friends.original.css\");\n@import url(\"https://steamloopback.host/friends.custom.css\");\n";
 
             // original overrides custom (!important tags needed, this is the original behavior)
             // string appendText = "@import url(\"https://steamloopback.host/friends.custom.css\");\n@import url(\"https://steamloopback.host/friends.original.css\");\n{";

--- a/Program.cs
+++ b/Program.cs
@@ -292,7 +292,7 @@ namespace SteamFriendsPatcher
 
             // custom overrides original (!important tags not needed)
             const string appendText =
-                "@import url(\"https://steamloopback.host/friends.original.css\");\n@import url(\"https://steamloopback.host/friends.custom.css\");\n";
+                "@import url(\"https://steamloopback.host/friends.original.css\");\n@import url(\"https://steamloopback.host/friends.custom.css\");\n{";
 
             // original overrides custom (!important tags needed, this is the original behavior)
             // string appendText = "@import url(\"https://steamloopback.host/friends.custom.css\");\n@import url(\"https://steamloopback.host/friends.original.css\");\n{";


### PR DESCRIPTION
## Clear Steam Cache uses steam launch args

Previously using the Clear Steam Cache option would not relaunch steam with the specified Steam Launch Arguments. 2dea914 fixes this.

e.g will launch `steam -dev` rather than just `steam` if `-dev` is set as a launch argument
